### PR TITLE
Report wikit-core version as an extra (SUP-81)

### DIFF
--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -346,7 +346,31 @@ final class Monitor {
 			$data['php_version'] = PHP_VERSION;
 		}
 
+		$wikit_core_version = $this->get_wikit_core_version();
+
+		if ( ! empty( $wikit_core_version ) ) {
+			$data['wikit_core_version'] = $wikit_core_version;
+		}
+
 		return $data;
+	}
+
+	/**
+	 * Get the installed wdgdc/wikit-core version, if present on this site.
+	 *
+	 * @return string|null - installed version, or null if wikit-core isn't installed
+	 * @access private
+	 */
+	private function get_wikit_core_version() {
+		if ( ! class_exists( '\Composer\InstalledVersions' ) ) {
+			return null;
+		}
+
+		try {
+			return \Composer\InstalledVersions::getVersion( 'wdgdc/wikit-core' );
+		} catch ( \OutOfBoundsException $e ) {
+			return null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- `compile_extras()` now also reports `wikit_core_version` alongside `php_version`, read via `\Composer\InstalledVersions::getVersion('wdgdc/wikit-core')`.
- wikit-core has no VERSION constant in its own source (`src/constants.php` only defines `WIKIT_DIR`/`WIKIT_URI`) — it's versioned purely through git tags/Composer, so the Composer runtime API is the only reliable source of truth for "what version is actually installed on this site."
- Defensive: guarded with `class_exists()` (older Composer 1.x sites, or sites where nothing ever loaded a Composer autoloader) and a try/catch around `getVersion()` (throws `OutOfBoundsException` when the package isn't installed at all). Sites without wikit-core simply omit the key from `extras`, same as any other optional value.

Jira: [SUP-81](https://webdevelopmentgroup.atlassian.net/browse/SUP-81)
Also tracked as: https://github.com/wdgdc/wdg-dashboard-support-monitor/issues/1

Companion PR on the dashboard side (renders this value): https://github.com/wdgdc/wdg-dashboard-support-monitor/pull/86

## Test plan
- [x] `php -l src/Monitor.php` — no syntax errors
- [ ] On a site with wikit-core installed via Composer, confirm the outgoing POST payload's `extras.wikit_core_version` matches the actual installed version (e.g. via `composer show wdgdc/wikit-core`)
- [ ] On a site without wikit-core, confirm `compile_extras()` doesn't error and simply omits the key

[SUP-81]: https://webdevelopmentgroup.atlassian.net/browse/SUP-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ